### PR TITLE
chore(deps): update `quote` 0.6 -> 1.0, `syn` 0.15 -> 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ keywords = ["enum", "derive", "variant", "count"]
 categories = ["rust-patterns"]
 
 [dependencies]
-quote = "0.6"
-syn = "0.15"
+quote = "1.0"
+syn = "1.0"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
This allows `variant_count` to avoid adding unnecessary dependencies in a post-1.0 world for `syn` and `quote`. :)