### PR TITLE
deps: allow both syn 1.0 and 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["rust-patterns"]
 
 [dependencies]
 quote = "1.0"
-syn = "1.0"
+syn = ">=1, <3"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
`variant_count` works with both from what I see so allowing both is just the more flexible option for downstream users.

This is a non-breaking change since I don't think anything from `syn` is exposed in the public API so a patch release should work.
